### PR TITLE
Fix TMX/TSX margin and spacing property transfer

### DIFF
--- a/RELEASE-NOTES-v1.0.11.md
+++ b/RELEASE-NOTES-v1.0.11.md
@@ -73,6 +73,24 @@
 ```
 
 ## 🐛 Bug Fixes
+
+### TMX/TSX Property Transfer Fix
+- **Fixed Missing Tileset Properties**: Margin and spacing attributes from TSX files are now properly preserved in JSON output
+  - Tileset `margin` attribute correctly transferred from TSX to output JSON
+  - Tileset `spacing` attribute correctly transferred from TSX to output JSON
+  - Previously these values were always showing as 0 regardless of TSX file settings
+- **Complete Property Coverage**: All TMX/TSX properties are now comprehensively preserved:
+  - ✅ Map-level properties (root element custom properties)
+  - ✅ Tile layer properties (layer-specific metadata)
+  - ✅ Object layer properties (object group metadata)
+  - ✅ Individual object properties (with proper type conversion)
+  - ✅ Individual tile properties (static and animated tiles)
+  - ✅ Tileset properties (including margin/spacing attributes)
+- **Enhanced Test Coverage**: Added comprehensive tests to prevent regression of property transfer functionality
+
+### Impact
+This fix ensures that all custom metadata and layout information from Tiled map editors is accurately preserved when converting to MonoGame format, maintaining the complete fidelity of map data.
+
 - Fixed compilation issues in unit tests after API changes
 - Improved error messaging for TMX processing failures
 

--- a/examples/maps/output/desert-atlas.json
+++ b/examples/maps/output/desert-atlas.json
@@ -29,7 +29,7 @@
   ],
   "metadata": {
     "version": "1.0.0",
-    "generated": "2025-12-26T21:46:28.7968416Z",
+    "generated": "2026-01-12T01:26:57.9368166Z",
     "sources": [
       "sample-map.tmx",
       "subfolder-test.tmx"

--- a/examples/maps/output/desert-map.json
+++ b/examples/maps/output/desert-map.json
@@ -15,8 +15,8 @@
         "tileHeight": 32,
         "tileCount": 48,
         "columns": 8,
-        "margin": 0,
-        "spacing": 0,
+        "margin": 1,
+        "spacing": 1,
         "atlasSprite": "desert_tmw_desert_spacing",
         "tiles": [
           {
@@ -956,8 +956,8 @@
         "tileHeight": 32,
         "tileCount": 48,
         "columns": 8,
-        "margin": 0,
-        "spacing": 0,
+        "margin": 1,
+        "spacing": 1,
         "atlasSprite": "oasis_subfolder_tiles",
         "tiles": [],
         "properties": {}

--- a/examples/tiled-map/output/atlas.json
+++ b/examples/tiled-map/output/atlas.json
@@ -1,0 +1,33 @@
+{
+  "width": 512,
+  "height": 512,
+  "sprites": [
+    {
+      "name": "map_grass_tiles",
+      "x": 2,
+      "y": 2,
+      "width": 267,
+      "height": 402,
+      "rotated": false,
+      "sourceWidth": 512,
+      "sourceHeight": 512,
+      "trimX": 2,
+      "trimY": 2
+    }
+  ],
+  "metadata": {
+    "version": "1.0.0",
+    "generated": "2026-01-12T01:26:38.6763581Z",
+    "sources": [
+      "simple_map.tmx"
+    ],
+    "settings": {
+      "maxWidth": 512,
+      "maxHeight": 512,
+      "padding": 2,
+      "allowRotation": false,
+      "trimSprites": true,
+      "powerOfTwo": true
+    }
+  }
+}

--- a/examples/tiled-map/output/map.json
+++ b/examples/tiled-map/output/map.json
@@ -1,0 +1,345 @@
+[
+  {
+    "name": "mapmap",
+    "width": 8,
+    "height": 6,
+    "tileWidth": 32,
+    "tileHeight": 32,
+    "orientation": "orthogonal",
+    "backgroundColor": null,
+    "tilesets": [
+      {
+        "name": "grass_tileset",
+        "firstGid": 1,
+        "tileWidth": 32,
+        "tileHeight": 32,
+        "tileCount": 9,
+        "columns": 3,
+        "margin": 0,
+        "spacing": 0,
+        "atlasSprite": "map_grass_tiles",
+        "tiles": [
+          {
+            "id": 0,
+            "type": null,
+            "atlasSprite": null,
+            "animation": null,
+            "collisionObjects": null,
+            "properties": {
+              "type": "grass",
+              "walkable": true
+            }
+          },
+          {
+            "id": 1,
+            "type": null,
+            "atlasSprite": null,
+            "animation": null,
+            "collisionObjects": null,
+            "properties": {
+              "type": "grass_flower",
+              "walkable": true
+            }
+          },
+          {
+            "id": 4,
+            "type": null,
+            "atlasSprite": null,
+            "animation": null,
+            "collisionObjects": null,
+            "properties": {
+              "type": "stone",
+              "walkable": false
+            }
+          },
+          {
+            "id": 8,
+            "type": null,
+            "atlasSprite": null,
+            "animation": [
+              {
+                "tileId": 8,
+                "duration": 500,
+                "sourceX": 64,
+                "sourceY": 64,
+                "sourceWidth": 32,
+                "sourceHeight": 32
+              },
+              {
+                "tileId": 7,
+                "duration": 500,
+                "sourceX": 32,
+                "sourceY": 64,
+                "sourceWidth": 32,
+                "sourceHeight": 32
+              },
+              {
+                "tileId": 6,
+                "duration": 500,
+                "sourceX": 0,
+                "sourceY": 64,
+                "sourceWidth": 32,
+                "sourceHeight": 32
+              }
+            ],
+            "collisionObjects": null,
+            "properties": {
+              "type": "water",
+              "walkable": false
+            }
+          }
+        ],
+        "properties": {
+          "description": "A simple grass tileset for testing"
+        }
+      }
+    ],
+    "tileLayers": [
+      {
+        "id": 1,
+        "name": "Ground",
+        "width": 8,
+        "height": 6,
+        "opacity": 1,
+        "visible": true,
+        "offsetX": 0,
+        "offsetY": 0,
+        "tiles": [
+          1,
+          1,
+          2,
+          1,
+          1,
+          1,
+          2,
+          1,
+          1,
+          2,
+          1,
+          1,
+          2,
+          1,
+          1,
+          1,
+          1,
+          1,
+          1,
+          5,
+          5,
+          1,
+          1,
+          2,
+          2,
+          1,
+          1,
+          5,
+          5,
+          1,
+          1,
+          1,
+          1,
+          1,
+          2,
+          1,
+          1,
+          2,
+          1,
+          1,
+          1,
+          2,
+          1,
+          1,
+          1,
+          1,
+          2,
+          1
+        ],
+        "properties": {
+          "layer_type": "background"
+        }
+      },
+      {
+        "id": 2,
+        "name": "Water",
+        "width": 8,
+        "height": 6,
+        "opacity": 1,
+        "visible": true,
+        "offsetX": 0,
+        "offsetY": 0,
+        "tiles": [
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          9,
+          9,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          9,
+          9,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0,
+          0
+        ],
+        "properties": {
+          "layer_type": "decoration"
+        }
+      }
+    ],
+    "objectLayers": [
+      {
+        "id": 3,
+        "name": "Objects",
+        "opacity": 1,
+        "visible": true,
+        "offsetX": 0,
+        "offsetY": 0,
+        "objects": [
+          {
+            "id": 1,
+            "name": "spawn_point",
+            "type": "PlayerSpawn",
+            "objectType": "rectangle",
+            "x": 32,
+            "y": 32,
+            "width": 32,
+            "height": 32,
+            "rotation": 0,
+            "gid": 0,
+            "visible": true,
+            "polygon": null,
+            "polyline": null,
+            "text": null,
+            "properties": {
+              "team": "blue"
+            }
+          },
+          {
+            "id": 2,
+            "name": "treasure_chest",
+            "type": "Chest",
+            "objectType": "rectangle",
+            "x": 160,
+            "y": 96,
+            "width": 32,
+            "height": 32,
+            "rotation": 0,
+            "gid": 0,
+            "visible": true,
+            "polygon": null,
+            "polyline": null,
+            "text": null,
+            "properties": {
+              "contents": "gold_coins",
+              "locked": true
+            }
+          },
+          {
+            "id": 3,
+            "name": "collision_area",
+            "type": "CollisionBox",
+            "objectType": "rectangle",
+            "x": 128,
+            "y": 64,
+            "width": 64,
+            "height": 64,
+            "rotation": 0,
+            "gid": 0,
+            "visible": true,
+            "polygon": null,
+            "polyline": null,
+            "text": null,
+            "properties": {
+              "solid": true
+            }
+          },
+          {
+            "id": 4,
+            "name": "patrol_path",
+            "type": "Path",
+            "objectType": "polyline",
+            "x": 64,
+            "y": 128,
+            "width": 0,
+            "height": 0,
+            "rotation": 0,
+            "gid": 0,
+            "visible": true,
+            "polygon": null,
+            "polyline": [
+              {
+                "x": 0,
+                "y": 0
+              },
+              {
+                "x": 64,
+                "y": 0
+              },
+              {
+                "x": 64,
+                "y": 32
+              },
+              {
+                "x": 0,
+                "y": 32
+              },
+              {
+                "x": 0,
+                "y": 0
+              }
+            ],
+            "text": null,
+            "properties": {
+              "speed": 2.5
+            }
+          }
+        ],
+        "properties": {
+          "layer_type": "collision"
+        }
+      }
+    ],
+    "imageLayers": [],
+    "properties": {
+      "author": "PPacker Example",
+      "description": "Simple test map for Tiled integration"
+    },
+    "atlasFile": "atlas.png"
+  }
+]

--- a/src/PPacker/Core/TiledMapProcessor.cs
+++ b/src/PPacker/Core/TiledMapProcessor.cs
@@ -392,6 +392,8 @@ public static class TiledMapProcessor
             TileHeight = tileset.TileHeight,
             TileCount = tileset.TileCount,
             Columns = tileset.Columns,
+            Margin = tileset.Margin,
+            Spacing = tileset.Spacing,
             Properties = ParseProperties(tileset.Properties)
         };
 

--- a/tests/PPacker.Tests/Core/TiledMapProcessorTests.cs
+++ b/tests/PPacker.Tests/Core/TiledMapProcessorTests.cs
@@ -32,10 +32,10 @@ namespace PPacker.Tests.Core
 
         private void CreateTestFiles()
         {
-            // Create a simple TSX file
+            // Create a simple TSX file with margin and spacing
             var tsxContent = """
                 <?xml version="1.0" encoding="UTF-8"?>
-                <tileset version="1.10" tiledversion="1.10.2" name="test_tileset" tilewidth="32" tileheight="32" tilecount="4" columns="2">
+                <tileset version="1.10" tiledversion="1.10.2" name="test_tileset" tilewidth="32" tileheight="32" spacing="2" margin="1" tilecount="4" columns="2">
                  <properties>
                   <property name="description" value="Test tileset"/>
                  </properties>
@@ -457,6 +457,81 @@ namespace PPacker.Tests.Core
             Assert.Equal(150, frame3.Duration);
             Assert.Equal(1, frame3.SourceX); // margin + 0 * (tileWidth + spacing) = 1 + 0 * 33 = 1
             Assert.Equal(34, frame3.SourceY); // margin + 1 * (tileHeight + spacing) = 1 + 1 * 33 = 34
+        }
+
+        [Fact]
+        public async Task LoadTilesetAsync_ShouldPreserveMarginAndSpacing()
+        {
+            // Act
+            var tileset = await TiledMapProcessor.LoadTilesetAsync(_testTsxPath);
+
+            // Assert
+            Assert.Equal("test_tileset", tileset.Name);
+            Assert.Equal(32, tileset.TileWidth);
+            Assert.Equal(32, tileset.TileHeight);
+            Assert.Equal(4, tileset.TileCount);
+            Assert.Equal(2, tileset.Columns);
+            Assert.Equal(1, tileset.Margin); // Should load margin from TSX
+            Assert.Equal(2, tileset.Spacing); // Should load spacing from TSX
+            Assert.NotNull(tileset.Properties);
+            Assert.Equal("Test tileset", tileset.Properties.Properties.FirstOrDefault(p => p.Name == "description")?.Value);
+        }
+
+        [Fact]
+        public void ConvertToMapData_ShouldPreserveMarginAndSpacingProperties()
+        {
+            // Arrange
+            var tiledMap = new TiledMap
+            {
+                Width = 2,
+                Height = 2,
+                TileWidth = 32,
+                TileHeight = 32,
+                Orientation = "orthogonal",
+                Tilesets = new List<TiledTilesetRef>
+                {
+                    new()
+                    {
+                        Name = "test_tileset",
+                        FirstGid = 1,
+                        TileWidth = 32,
+                        TileHeight = 32,
+                        TileCount = 4,
+                        Columns = 2,
+                        Margin = 5,
+                        Spacing = 3,
+                        Properties = new TiledProperties
+                        {
+                            Properties = new List<TiledProperty>
+                            {
+                                new() { Name = "tileset_prop", Value = "test_value" }
+                            }
+                        }
+                    }
+                },
+                Layers = new List<TiledLayer>(),
+                ObjectGroups = new List<TiledObjectGroup>(),
+                ImageLayers = new List<TiledImageLayer>()
+            };
+
+            var imageToSpriteMap = new Dictionary<string, string>();
+
+            // Act
+            var mapData = TiledMapProcessor.ConvertToMapData(tiledMap, imageToSpriteMap, "test-atlas.png", "test-map");
+
+            // Assert
+            Assert.Single(mapData.Tilesets);
+            var tileset = mapData.Tilesets[0];
+            Assert.Equal("test_tileset", tileset.Name);
+            Assert.Equal(1, tileset.FirstGid);
+            Assert.Equal(32, tileset.TileWidth);
+            Assert.Equal(32, tileset.TileHeight);
+            Assert.Equal(4, tileset.TileCount);
+            Assert.Equal(2, tileset.Columns);
+            Assert.Equal(5, tileset.Margin); // Should preserve margin
+            Assert.Equal(3, tileset.Spacing); // Should preserve spacing
+            Assert.NotNull(tileset.Properties);
+            Assert.Equal("test_value", tileset.Properties["tileset_prop"]);
         }
 
         [Fact]


### PR DESCRIPTION
- Add missing Margin and Spacing property assignments in ConvertTileset method
- Tileset margin/spacing attributes from TSX files are now properly preserved in JSON output
- Add comprehensive tests to verify margin/spacing property transfer from TSX to MapData
- All other TMX/TSX properties (map, layer, tile, object properties) continue to work correctly
- Fixes issue #9: Map parameters not transferring

Version: 1.0.11